### PR TITLE
chore: run "sync" workflow only on main branch (GEA-11243)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,6 +1,9 @@
 name: Sync
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   sync:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Create a file `.github/workflows/sync.yml` which contains the following workflow
 ```yml
 name: Sync
 
-on: [push]
+on:
+  push:
+    branches:
+      # Replace with configured GitHub default branch.
+      - main
 
 jobs:
   sync:


### PR DESCRIPTION
The README says that the "sync" workflow only works on the configured GitHub default branch but then the project itself doesn't adhere to this. This causes all PR branches to have a failed "sync" run. This patch fixes this by updating the workflow to only run on the default branch.